### PR TITLE
Implement vanilla coloring web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# tomautranh
+# Ứng dụng Tô Màu Trực Tuyến
+
+Ứng dụng web thuần HTML/CSS/JavaScript cho phép người dùng tô màu tranh đen trắng, vẽ tự do, đổ màu và lưu bản vẽ trực tiếp trên trình duyệt.
+
+## Tính năng nổi bật
+- Thư viện tranh SVG mẫu và hỗ trợ tải ảnh PNG/JPG/SVG của riêng bạn (giới hạn 10MB).
+- Công cụ cọ, tẩy, đổ màu (có thể điều chỉnh dung sai) và hút màu trực tiếp trên canvas.
+- Bảng màu cơ bản 24 sắc, thêm màu tùy chỉnh và lưu tối đa 12 màu yêu thích (click chuột phải để xóa).
+- Lịch sử hoàn tác/làm lại 50 bước, lưu tạm tự động và xuất ảnh PNG.
+- Hỗ trợ zoom/pan, gradient fill, phím tắt Ctrl+Z / Ctrl+Y.
+
+## Khởi chạy
+Chỉ cần mở file `src/index.html` trong trình duyệt hiện đại (Chrome, Firefox, Safari, Edge).
+
+> Ứng dụng không phụ thuộc framework hay thư viện ngoài nào.

--- a/docs/software_requirements.md
+++ b/docs/software_requirements.md
@@ -1,0 +1,498 @@
+# TÀI LIỆU YÊU CẦU PHẦN MỀM
+## Ứng dụng Tô Màu Tranh Trực Tuyến
+
+### 1. TỔNG QUAN DỰ ÁN
+
+#### 1.1 Mục đích
+Phát triển ứng dụng web cho phép người dùng tô màu các bức tranh đen trắng một cách tương tác trên nhiều thiết bị (desktop, tablet, mobile).
+
+#### 1.2 Phạm vi
+- Platform: Web responsive (HTML5/CSS3/JavaScript thuần)
+- Thiết bị hỗ trợ: Desktop (Chrome, Firefox, Safari, Edge), Mobile (iOS Safari, Chrome Android)
+- Không yêu cầu cài đặt, chạy trực tiếp trên trình duyệt
+
+#### 1.3 Định nghĩa và từ viết tắt
+- **Canvas**: HTML5 Canvas element để vẽ đồ họa
+- **Flood Fill**: Thuật toán tô màu vùng kín
+- **SVG**: Scalable Vector Graphics
+- **PWA**: Progressive Web App
+
+### 2. YÊU CẦU CHỨC NĂNG
+
+#### 2.1 Chức năng cốt lõi
+
+##### F001: Tải và hiển thị tranh
+- Hỗ trợ định dạng: PNG, JPG, SVG
+- Tự động phát hiện vùng tô màu (contour detection)
+- Chuyển đổi ảnh màu thành line art nếu cần
+- Gallery mẫu có sẵn (10-20 tranh)
+
+##### F002: Bảng màu
+- Palette màu cơ bản (24 màu)
+- Color picker tùy chỉnh
+- Lưu màu yêu thích (max 12)
+- Hiển thị màu đang chọn
+- Eyedropper tool để lấy màu từ tranh
+
+##### F003: Tô màu
+- Click/tap để tô màu vùng kín
+- Flood fill algorithm với tolerance điều chỉnh
+- Hỗ trợ gradient fill (nâng cao)
+- Preview màu khi hover (desktop)
+
+##### F004: Công cụ vẽ
+- Brush tool với kích thước điều chỉnh (1-50px)
+- Eraser tool
+- Paint bucket (flood fill)
+- Zoom in/out (25%-400%)
+- Pan tool để di chuyển canvas
+
+##### F005: Undo/Redo
+- Lịch sử 50 bước
+- Keyboard shortcuts (Ctrl+Z, Ctrl+Y)
+- Clear all với xác nhận
+
+##### F006: Lưu và chia sẻ
+- Lưu tạm vào localStorage
+- Export PNG/JPG với chất lượng tùy chọn
+- Chia sẻ qua social media (URL share)
+- Tải về thiết bị
+
+#### 2.2 Chức năng nâng cao
+
+##### F007: Layers
+- Tối đa 5 layers
+- Opacity điều chỉnh cho mỗi layer
+- Blend modes cơ bản
+
+##### F008: Effects
+- Blur effect
+- Shadow/glow
+- Texture overlays
+
+##### F009: Multiplayer
+- Tô màu cùng nhau real-time
+- Chat trong phòng
+- Lưu lịch sử người tham gia
+
+### 3. YÊU CẦU PHI CHỨC NĂNG
+
+#### 3.1 Hiệu năng
+- **NFR001**: Thời gian tải trang < 3 giây (3G network)
+- **NFR002**: Flood fill < 100ms cho ảnh 1920x1080
+- **NFR003**: Smooth drawing ở 60 FPS
+- **NFR004**: Hỗ trợ canvas lên đến 4096x4096 pixels
+
+#### 3.2 Khả năng sử dụng
+- **NFR005**: Responsive design cho màn hình 320px - 4K
+- **NFR006**: Touch gestures cho mobile (pinch zoom, 2-finger pan)
+- **NFR007**: Keyboard navigation hỗ trợ accessibility
+- **NFR008**: Tutorial cho người dùng mới
+
+#### 3.3 Độ tin cậy
+- **NFR009**: Auto-save mỗi 30 giây
+- **NFR010**: Recovery sau khi browser crash
+- **NFR011**: Offline mode với service worker
+
+#### 3.4 Bảo mật
+- **NFR012**: Validate input files (size < 10MB, format check)
+- **NFR013**: Sanitize user-generated content
+- **NFR014**: CORS policy cho image loading
+- **NFR015**: Rate limiting cho API calls
+
+#### 3.5 Tương thích
+- **NFR016**: Chrome 90+, Firefox 88+, Safari 14+, Edge 90+
+- **NFR017**: iOS 13+, Android 8+
+- **NFR018**: Fallback cho browsers không hỗ trợ
+
+### 4. KIẾN TRÚC KỸ THUẬT
+
+#### 4.1 Frontend Architecture
+```
+/src
+├── /assets
+│   ├── /images     # Sample coloring pages
+│   ├── /icons      # UI icons
+│   └── /fonts      # Custom fonts
+├── /css
+│   ├── main.css    # Main styles
+│   ├── mobile.css  # Mobile specific
+│   └── print.css   # Print styles
+├── /js
+│   ├── app.js      # Main application
+│   ├── canvas.js   # Canvas operations
+│   ├── colorpicker.js
+│   ├── floodfill.js
+│   ├── history.js  # Undo/redo manager
+│   ├── storage.js  # LocalStorage handler
+│   └── utils.js
+└── index.html
+```
+
+#### 4.2 Data Structure
+```javascript
+// Coloring Session
+{
+  id: "uuid",
+  imageUrl: "base64/url",
+  dimensions: { width, height },
+  layers: [
+    {
+      id: "layer-id",
+      data: ImageData,
+      opacity: 1.0,
+      visible: true
+    }
+  ],
+  history: [
+    {
+      action: "fill/draw/erase",
+      data: {...},
+      timestamp: Date
+    }
+  ],
+  palette: ["#FF0000", "#00FF00", ...],
+  metadata: {
+    created: Date,
+    modified: Date,
+    title: String
+  }
+}
+```
+
+#### 4.3 Algorithms
+
+##### Flood Fill Algorithm
+```javascript
+// Scanline flood fill với stack
+function floodFill(x, y, targetColor, fillColor, tolerance) {
+  // 1. Check boundaries
+  // 2. Get pixel color
+  // 3. Compare với tolerance
+  // 4. Fill horizontal line
+  // 5. Check lines above/below
+  // 6. Add to stack
+  // 7. Repeat
+}
+```
+
+### 5. GIAO DIỆN NGƯỜI DÙNG
+
+#### 5.1 Desktop Layout
+```
+┌─────────────────────────────────────┐
+│  Header (Logo, Menu, Save)          │
+├──────┬──────────────────────┬───────┤
+│      │                      │       │
+│ Tool │   Canvas Area        │ Color │
+│ Bar  │   (Zoomable)         │Palette│
+│      │                      │       │
+├──────┴──────────────────────┴───────┤
+│  Footer (Zoom, Undo/Redo)           │
+└─────────────────────────────────────┘
+```
+
+#### 5.2 Mobile Layout
+```
+┌─────────────┐
+│   Header    │
+├─────────────┤
+│             │
+│   Canvas    │
+│             │
+├─────────────┤
+│Color Palette│
+├─────────────┤
+│  Tool Bar   │
+└─────────────┘
+```
+
+### 6. TEST SCENARIOS
+
+#### 6.1 Functional Tests
+- **TC001**: Upload image và detect edges
+- **TC002**: Flood fill với các tolerance levels
+- **TC003**: Undo/redo 50 operations
+- **TC004**: Save/load từ localStorage
+- **TC005**: Export các định dạng
+- **TC006**: Zoom/pan operations
+- **TC007**: Touch gestures trên mobile
+
+#### 6.2 Performance Tests
+- **TC008**: Fill large area (>500K pixels)
+- **TC009**: Multiple layers rendering
+- **TC010**: Memory usage với canvas 4K
+
+#### 6.3 Compatibility Tests
+- **TC011**: Cross-browser testing
+- **TC012**: Responsive breakpoints
+- **TC013**: Touch vs mouse events
+
+### 7. MILESTONES & DELIVERABLES
+
+#### Phase 1: MVP (2 tuần)
+- Basic canvas setup
+- Flood fill implementation
+- Color palette
+- Save/load localStorage
+
+#### Phase 2: Enhanced (1 tuần)
+- Undo/redo
+- Zoom/pan
+- Mobile optimization
+- Gallery
+
+#### Phase 3: Polish (1 tuần)
+- Performance optimization
+- PWA features
+- Testing & bug fixes
+- Documentation
+
+### 8. RISKS & MITIGATION
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Flood fill performance issues | High | Medium | Implement web workers |
+| Browser compatibility | Medium | Low | Polyfills và fallbacks |
+| Memory leaks với large canvas | High | Medium | Canvas recycling, dispose properly |
+| Touch accuracy trên mobile | Medium | High | Zoom feature, larger touch targets |
+
+### 9. DEPENDENCIES
+
+#### External Libraries (Optional)
+- **None required** (vanilla JS implementation)
+- Optional enhancements:
+  - FileSaver.js cho download
+  - Pica.js cho image resizing
+  - Workbox cho PWA
+
+### 10. ACCEPTANCE CRITERIA
+
+- Tô màu mượt mà không lag trên thiết bị mid-range
+- Hỗ trợ ít nhất 95% browsers theo caniuse.com
+- Load time < 3s trên 3G
+- No memory leaks sau 1 giờ sử dụng
+- Touch precision ±5px trên mobile
+- Accessibility score > 90 (Lighthouse)
+
+### 11. USER STORIES
+
+#### 11.1 Epic: Người dùng tô màu tranh
+
+**US001**: Là người dùng, tôi muốn chọn tranh từ thư viện có sẵn
+- **Acceptance Criteria**:
+  - Hiển thị ít nhất 20 tranh mẫu
+  - Preview thumbnail trước khi chọn
+  - Phân loại theo chủ đề (động vật, phong cảnh, mandala...)
+  
+**US002**: Là người dùng, tôi muốn tải tranh của riêng mình
+- **Acceptance Criteria**:
+  - Hỗ trợ drag & drop
+  - Validate định dạng và kích thước
+  - Tự động convert sang line art nếu cần
+
+**US003**: Là người dùng, tôi muốn tô màu bằng cách tap/click vào vùng
+- **Acceptance Criteria**:
+  - Tô màu tức thì < 100ms
+  - Không tràn ra ngoài đường viền
+  - Hỗ trợ undo nếu tô sai
+
+**US004**: Là người dùng, tôi muốn lưu và tiếp tục sau
+- **Acceptance Criteria**:
+  - Auto-save mỗi 30 giây
+  - Khôi phục đúng trạng thái
+  - Không mất dữ liệu khi refresh
+
+**US005**: Là người dùng, tôi muốn chia sẻ tác phẩm
+- **Acceptance Criteria**:
+  - Export chất lượng cao
+  - Share link trực tiếp
+  - Watermark tùy chọn
+
+#### 11.2 Epic: Công cụ vẽ nâng cao
+
+**US006**: Là người dùng nâng cao, tôi muốn dùng brush để vẽ tự do
+- **Acceptance Criteria**:
+  - Brush size 1-50px
+  - Pressure sensitivity (nếu có stylus)
+  - Smooth stroke rendering
+
+**US007**: Là người dùng, tôi muốn mix màu và tạo gradient
+- **Acceptance Criteria**:
+  - Color mixing tool
+  - Gradient fill với 2+ màu
+  - Opacity control
+
+### 12. USE CASES
+
+#### UC001: Tô màu cơ bản
+**Actor**: Người dùng
+**Precondition**: Ứng dụng đã load, tranh đã chọn
+**Main Flow**:
+1. Người dùng chọn màu từ palette
+2. Người dùng click/tap vào vùng cần tô
+3. Hệ thống thực hiện flood fill
+4. Vùng được tô màu hiển thị
+5. Lưu vào history để undo
+
+**Alternative Flow**:
+- 2a. Vùng không kín → Hiện cảnh báo
+- 3a. Fill fail → Rollback và thông báo
+
+#### UC002: Import tranh tùy chỉnh
+**Actor**: Người dùng
+**Precondition**: Người dùng có file ảnh
+**Main Flow**:
+1. Người dùng click "Upload"
+2. Chọn file từ thiết bị
+3. System validate file
+4. Process và hiển thị preview
+5. Người dùng confirm
+6. Load tranh vào canvas
+
+**Exception Flow**:
+- 3a. File không hợp lệ → Báo lỗi
+- 4a. Ảnh quá lớn → Đề nghị resize
+
+### 13. BUSINESS REQUIREMENTS
+
+#### 13.1 Mục tiêu kinh doanh
+- **Người dùng mục tiêu**: 500,000 MAU trong năm đầu
+- **Engagement**: Average session 15 phút
+- **Retention**: 40% người dùng quay lại sau 7 ngày
+- **Monetization**: 
+  - Free tier: 5 tranh/ngày
+  - Premium: Unlimited + exclusive content
+  - Ads cho free users
+
+#### 13.2 KPIs
+- Daily Active Users (DAU)
+- Tranh được tô màu/ngày
+- Conversion rate free → premium
+- App store rating > 4.5
+
+#### 13.3 Competitive Analysis
+| Feature | Our App | Competitor A | Competitor B |
+|---------|---------|--------------|--------------|
+| Offline mode | ✓ | ✗ | ✓ |
+| Custom images | ✓ | Premium only | ✗ |
+| Multiplayer | ✓ | ✗ | ✗ |
+| No ads (free) | ✗ | ✗ | ✗ |
+| Web-based | ✓ | App only | ✓ |
+
+### 14. TECHNICAL SPECIFICATIONS
+
+#### 14.1 Browser APIs Required
+```javascript
+// Core APIs
+- Canvas 2D Context
+- File API
+- LocalStorage API  
+- Touch Events API
+- Pointer Events API
+- Fullscreen API
+- Web Workers (performance)
+- Service Workers (offline)
+```
+
+#### 14.2 Performance Budget
+- Initial load: < 200KB (gzipped)
+- Time to Interactive: < 3s
+- First Contentful Paint: < 1.5s
+- Memory usage: < 150MB
+- Battery drain: < 5%/hour
+
+#### 14.3 Data Schema
+```javascript
+// User Profile
+{
+  userId: String,
+  preferences: {
+    defaultPalette: Array<Color>,
+    brushSize: Number,
+    autoSave: Boolean
+  },
+  stats: {
+    completed: Number,
+    timeSpent: Number,
+    favoriteColors: Array
+  }
+}
+
+// Artwork
+{
+  artworkId: String,
+  originalImage: String(base64/url),
+  colorLayers: Array<ImageData>,
+  history: Array<Action>,
+  metadata: {
+    created: Timestamp,
+    modified: Timestamp,
+    shares: Number
+  }
+}
+```
+
+### 15. QUALITY ASSURANCE
+
+#### 15.1 Test Coverage Requirements
+- Unit tests: > 80% coverage
+- Integration tests: Core workflows
+- E2E tests: Critical user journeys
+- Performance tests: Load & stress testing
+- Usability tests: 10+ users
+
+#### 15.2 Bug Severity Levels
+- **P0 (Critical)**: App crash, data loss
+- **P1 (High)**: Core feature broken
+- **P2 (Medium)**: Feature degraded
+- **P3 (Low)**: Cosmetic issues
+
+#### 15.3 Device Testing Matrix
+| Device Type | OS Versions | Browsers | Priority |
+|-------------|------------|----------|----------|
+| iPhone | iOS 14+ | Safari, Chrome | P0 |
+| Android | 9+ | Chrome, Firefox | P0 |
+| iPad | iPadOS 14+ | Safari | P1 |
+| Desktop | Win 10+, Mac | Chrome, Edge, Firefox | P1 |
+
+### 16. DEPLOYMENT & MAINTENANCE
+
+#### 16.1 Deployment Strategy
+- Environment: Static hosting (CDN)
+- CI/CD: GitHub Actions
+- Monitoring: Google Analytics + Sentry
+- A/B Testing: Feature flags
+
+#### 16.2 Update Schedule
+- Bug fixes: Within 48 hours
+- Minor updates: Bi-weekly
+- Major features: Monthly
+- Security patches: Immediate
+
+### 17. COMPLIANCE & LEGAL
+
+#### 17.1 Privacy Requirements
+- GDPR compliance (EU users)
+- COPPA compliance (under 13)
+- Cookie consent banner
+- Data deletion on request
+
+#### 17.2 Content Guidelines
+- No copyrighted images in gallery
+- User-generated content moderation
+- Terms of Service & Privacy Policy
+- Age-appropriate content only
+
+### 18. FUTURE ENHANCEMENTS (v2.0)
+
+- AI-powered auto-coloring suggestions
+- AR mode (color real world)
+- Voice commands
+- Cloud sync across devices
+- Social features (follow, like, comment)
+- Coloring competitions
+- Educational mode with color theory
+- API for third-party integrations
+- Desktop app (Electron)
+- Marketplace for custom coloring books

--- a/src/assets/images/animals.svg
+++ b/src/assets/images/animals.svg
@@ -1,0 +1,25 @@
+<svg viewBox="0 0 700 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="700" height="500" fill="#fff"/>
+  <g fill="none" stroke="#111" stroke-width="4">
+    <circle cx="150" cy="220" r="80"/>
+    <circle cx="120" cy="190" r="20"/>
+    <circle cx="180" cy="190" r="20"/>
+    <path d="M120 260 Q150 300 180 260"/>
+    <path d="M90 160 L60 120"/>
+    <path d="M210 160 L240 120"/>
+
+    <circle cx="350" cy="230" r="70"/>
+    <circle cx="330" cy="210" r="15"/>
+    <circle cx="370" cy="210" r="15"/>
+    <path d="M320 250 Q350 280 380 250"/>
+    <path d="M310 170 L280 150"/>
+    <path d="M390 170 L420 150"/>
+
+    <circle cx="550" cy="220" r="60"/>
+    <circle cx="530" cy="200" r="12"/>
+    <circle cx="570" cy="200" r="12"/>
+    <path d="M520 240 Q550 260 580 240"/>
+    <path d="M520 170 L490 150"/>
+    <path d="M580 170 L610 150"/>
+  </g>
+</svg>

--- a/src/assets/images/landscape.svg
+++ b/src/assets/images/landscape.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="600" fill="#fff"/>
+  <g fill="none" stroke="#111" stroke-width="4">
+    <path d="M0 420 Q200 320 400 420 T800 420 V600 H0 Z"/>
+    <path d="M0 480 Q200 360 400 480 T800 480"/>
+    <circle cx="200" cy="200" r="80"/>
+    <path d="M120 240 Q200 160 280 240"/>
+    <path d="M50 420 L150 300 L250 420 Z"/>
+    <path d="M300 420 L420 260 L540 420 Z"/>
+    <path d="M500 420 L600 320 L700 420 Z"/>
+    <path d="M640 180 Q680 120 720 180"/>
+  </g>
+</svg>

--- a/src/assets/images/mandala.svg
+++ b/src/assets/images/mandala.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="600" fill="#fff"/>
+  <g fill="none" stroke="#111" stroke-width="4">
+    <circle cx="300" cy="300" r="240"/>
+    <circle cx="300" cy="300" r="180"/>
+    <circle cx="300" cy="300" r="120"/>
+    <circle cx="300" cy="300" r="60"/>
+    <path d="M300 60 L360 180 L540 180 L390 270 L450 420 L300 330 L150 420 L210 270 L60 180 L240 180 Z"/>
+    <path d="M300 540 L360 420 L540 420 L390 330 L450 180 L300 270 L150 180 L210 330 L60 420 L240 420 Z"/>
+  </g>
+</svg>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: #f3f4f6;
+  --surface-color: #ffffff;
+  --accent: #ff5252;
+  --accent-dark: #d32f2f;
+  --text-color: #1f2933;
+  --border-color: #d2d6dc;
+  --shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-color);
+  color: var(--text-color);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+.app-header,
+.app-footer {
+  background: var(--surface-color);
+  border-bottom: 1px solid var(--border-color);
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.app-footer {
+  border-top: 1px solid var(--border-color);
+  border-bottom: none;
+  bottom: 0;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.btn,
+.tool-btn {
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
+  color: inherit;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s;
+  font: inherit;
+}
+
+.btn:hover,
+.tool-btn:hover,
+.tool-btn.active {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+
+.btn.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.btn.primary:hover {
+  background: var(--accent-dark);
+}
+
+.btn.secondary {
+  background: #eef2f7;
+}
+
+.app-main {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 260px;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.tool-panel,
+.palette-panel {
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+}
+
+.tool-group h2 {
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #52606d;
+}
+
+.tool-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tool-btn {
+  text-align: left;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.control.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+input[type='range'] {
+  width: 100%;
+}
+
+.canvas-container {
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#canvas-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #fff;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+}
+
+#canvas-wrapper canvas {
+  background: #fff;
+  display: block;
+  margin: 0 auto;
+  touch-action: none;
+  transform-origin: top left;
+}
+
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+  gap: 0.5rem;
+}
+
+.color-swatch {
+  width: 36px;
+  height: 36px;
+  border-radius: 0.5rem;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, border 0.2s ease;
+}
+
+.color-swatch:focus,
+.color-swatch:hover {
+  transform: scale(1.05);
+  border-color: var(--accent);
+  outline: none;
+}
+
+.active-color {
+  width: 100%;
+  height: 48px;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+  background: #fff;
+}
+
+.history-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.app-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#gallery-dialog {
+  border: none;
+  padding: 0;
+  border-radius: 1rem;
+  width: min(90vw, 900px);
+  max-height: 90vh;
+  box-shadow: var(--shadow);
+}
+
+#gallery-dialog header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.gallery-item {
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+}
+
+.gallery-item span {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1200px) {
+  .app-main {
+    grid-template-columns: 220px minmax(0, 1fr) 220px;
+  }
+}
+
+@media (max-width: 960px) {
+  body {
+    grid-template-rows: auto auto 1fr auto;
+  }
+
+  .app-main {
+    grid-template-columns: 1fr;
+  }
+
+  .tool-panel,
+  .palette-panel {
+    max-height: none;
+    order: 1;
+  }
+
+  .canvas-container {
+    order: 0;
+    min-height: 60vh;
+  }
+}
+
+@media (max-width: 600px) {
+  .header-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .app-header {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .btn,
+  .tool-btn {
+    width: 100%;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tô Màu Tranh Trực Tuyến</title>
+    <link rel="stylesheet" href="css/main.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="logo">Tô Màu</div>
+      <nav class="header-actions">
+        <button id="open-gallery" class="btn">Thư viện</button>
+        <label for="file-upload" class="btn secondary">Tải tranh</label>
+        <input type="file" id="file-upload" accept="image/png,image/jpeg,image/svg+xml" hidden />
+        <button id="save-session" class="btn secondary">Lưu</button>
+        <button id="export-image" class="btn primary">Xuất ảnh</button>
+      </nav>
+    </header>
+
+    <main class="app-main">
+      <aside class="tool-panel" aria-label="Công cụ vẽ">
+        <section class="tool-group">
+          <h2>Công cụ</h2>
+          <button data-tool="brush" class="tool-btn active">Cọ</button>
+          <button data-tool="eraser" class="tool-btn">Tẩy</button>
+          <button data-tool="bucket" class="tool-btn">Đổ màu</button>
+          <button data-tool="eyedropper" class="tool-btn">Hút màu</button>
+          <button data-tool="pan" class="tool-btn">Di chuyển</button>
+        </section>
+        <section class="tool-group">
+          <h2>Thiết lập</h2>
+          <label class="control">
+            <span>Kích thước cọ</span>
+            <input type="range" id="brush-size" min="1" max="50" value="10" />
+          </label>
+          <label class="control">
+            <span>Dung sai đổ màu</span>
+            <input type="range" id="fill-tolerance" min="0" max="128" value="32" />
+          </label>
+          <label class="control checkbox">
+            <input type="checkbox" id="gradient-toggle" />
+            <span>Đổ gradient</span>
+          </label>
+          <label class="control">
+            <span>Thu phóng</span>
+            <input type="range" id="zoom-slider" min="25" max="400" value="100" />
+          </label>
+        </section>
+        <section class="tool-group">
+          <h2>Lịch sử</h2>
+          <div class="history-actions">
+            <button id="undo" class="btn secondary">Hoàn tác</button>
+            <button id="redo" class="btn secondary">Làm lại</button>
+            <button id="clear-canvas" class="btn secondary">Xóa hết</button>
+          </div>
+        </section>
+      </aside>
+
+      <section class="canvas-container" aria-label="Khu vực vẽ">
+        <div id="canvas-wrapper">
+          <canvas id="drawing-canvas" width="1024" height="768"></canvas>
+        </div>
+      </section>
+
+      <aside class="palette-panel" aria-label="Bảng màu">
+        <section class="tool-group">
+          <h2>Màu cơ bản</h2>
+          <div id="base-palette" class="color-grid" role="listbox" aria-label="Bảng màu cơ bản"></div>
+        </section>
+        <section class="tool-group">
+          <h2>Màu tùy chọn</h2>
+          <input type="color" id="color-picker" value="#ff5252" />
+          <button id="add-favorite" class="btn secondary">Thêm vào yêu thích</button>
+        </section>
+        <section class="tool-group">
+          <h2>Màu yêu thích</h2>
+          <div id="favorite-palette" class="color-grid" aria-label="Màu yêu thích"></div>
+        </section>
+        <section class="tool-group">
+          <h2>Màu đang chọn</h2>
+          <div id="active-color" class="active-color" aria-live="polite"></div>
+        </section>
+      </aside>
+    </main>
+
+    <footer class="app-footer">
+      <div class="footer-group">
+        <span>Phóng to: <span id="zoom-label">100%</span></span>
+      </div>
+      <div class="footer-group">
+        <span id="status-message" aria-live="polite">Sẵn sàng</span>
+      </div>
+    </footer>
+
+    <dialog id="gallery-dialog">
+      <header>
+        <h2>Thư viện tranh</h2>
+        <button id="close-gallery" class="btn secondary">Đóng</button>
+      </header>
+      <section id="gallery" class="gallery-grid" role="listbox"></section>
+    </dialog>
+
+    <script type="module" src="js/app.js"></script>
+  </body>
+</html>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,0 +1,223 @@
+import { CanvasManager } from './canvas.js';
+import { ColorPicker } from './colorpicker.js';
+import { HistoryManager } from './history.js';
+import { debounce, formatPercentage } from './utils.js';
+import { loadSession, saveSession } from './storage.js';
+
+const galleryImages = [
+  {
+    id: 'mandala',
+    title: 'Mandala thư giãn',
+    src: 'assets/images/mandala.svg'
+  },
+  {
+    id: 'landscape',
+    title: 'Cảnh biển',
+    src: 'assets/images/landscape.svg'
+  },
+  {
+    id: 'animals',
+    title: 'Bạn thú dễ thương',
+    src: 'assets/images/animals.svg'
+  }
+];
+
+class App {
+  constructor() {
+    this.canvasEl = document.getElementById('drawing-canvas');
+    this.history = new HistoryManager();
+    this.canvasManager = new CanvasManager(this.canvasEl, this.history, this.setStatus.bind(this));
+    this.colorPicker = new ColorPicker({
+      basePaletteEl: document.getElementById('base-palette'),
+      favoritePaletteEl: document.getElementById('favorite-palette'),
+      activeColorEl: document.getElementById('active-color'),
+      colorInput: document.getElementById('color-picker'),
+      addFavoriteBtn: document.getElementById('add-favorite'),
+      onColorChange: this.handleColorChange.bind(this)
+    });
+
+    this.statusEl = document.getElementById('status-message');
+    this.zoomLabel = document.getElementById('zoom-label');
+    this.toolButtons = document.querySelectorAll('[data-tool]');
+    this.fillToleranceInput = document.getElementById('fill-tolerance');
+    this.brushSizeInput = document.getElementById('brush-size');
+    this.gradientToggle = document.getElementById('gradient-toggle');
+    this.zoomSlider = document.getElementById('zoom-slider');
+    this.undoBtn = document.getElementById('undo');
+    this.redoBtn = document.getElementById('redo');
+    this.clearBtn = document.getElementById('clear-canvas');
+    this.exportBtn = document.getElementById('export-image');
+    this.saveBtn = document.getElementById('save-session');
+    this.fileUpload = document.getElementById('file-upload');
+    this.galleryDialog = document.getElementById('gallery-dialog');
+    this.openGalleryBtn = document.getElementById('open-gallery');
+    this.closeGalleryBtn = document.getElementById('close-gallery');
+    this.galleryEl = document.getElementById('gallery');
+
+    this.init();
+    this.canvasManager.setColorPickedCallback((color) => this.colorPicker.setActiveColor(color));
+  }
+
+  init() {
+    this.colorPicker.init();
+    this.attachEventListeners();
+    this.populateGallery();
+    this.restoreSession();
+  }
+
+  attachEventListeners() {
+    this.toolButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        this.toolButtons.forEach((btn) => btn.classList.remove('active'));
+        button.classList.add('active');
+        this.canvasManager.setTool(button.dataset.tool);
+        this.setStatus(`Đang chọn công cụ: ${button.textContent}`);
+      });
+    });
+
+    this.fillToleranceInput.addEventListener('input', (event) => {
+      this.canvasManager.setFillTolerance(Number(event.target.value));
+    });
+
+    this.brushSizeInput.addEventListener('input', (event) => {
+      this.canvasManager.setBrushSize(Number(event.target.value));
+    });
+
+    this.gradientToggle.addEventListener('change', (event) => {
+      this.canvasManager.setGradient(event.target.checked);
+    });
+
+    this.zoomSlider.addEventListener('input', (event) => {
+      const zoomValue = Number(event.target.value);
+      this.canvasManager.setZoom(zoomValue);
+      this.zoomLabel.textContent = formatPercentage(zoomValue);
+    });
+
+    this.undoBtn.addEventListener('click', () => this.canvasManager.undo());
+    this.redoBtn.addEventListener('click', () => this.canvasManager.redo());
+    this.clearBtn.addEventListener('click', () => this.canvasManager.clear());
+
+    this.exportBtn.addEventListener('click', () => {
+      const dataUrl = this.canvasManager.exportImage('image/png');
+      const link = document.createElement('a');
+      link.href = dataUrl;
+      link.download = 'tomautranh.png';
+      link.click();
+      this.setStatus('Đã xuất ảnh PNG.');
+    });
+
+    const debouncedSave = debounce(() => this.persistSession(), 1000);
+
+    ['pointerup', 'touchend'].forEach((eventName) => {
+      this.canvasEl.addEventListener(eventName, () => {
+        debouncedSave();
+      });
+    });
+
+    this.saveBtn.addEventListener('click', () => {
+      this.persistSession(true);
+    });
+
+    this.fileUpload.addEventListener('change', (event) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      if (!['image/png', 'image/jpeg', 'image/svg+xml'].includes(file.type) || file.size > 10 * 1024 * 1024) {
+        this.setStatus('File không hợp lệ.');
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const image = new Image();
+        image.onload = () => this.canvasManager.loadImage(image);
+        image.src = reader.result;
+      };
+      reader.readAsDataURL(file);
+    });
+
+    this.openGalleryBtn.addEventListener('click', () => {
+      this.galleryDialog.showModal();
+    });
+
+    this.closeGalleryBtn.addEventListener('click', () => this.galleryDialog.close());
+
+    this.galleryEl.addEventListener('click', (event) => {
+      const item = event.target.closest('[data-id]');
+      if (!item) return;
+      const image = new Image();
+      image.onload = () => {
+        this.canvasManager.loadImage(image);
+        this.galleryDialog.close();
+      };
+      image.src = item.dataset.src;
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.ctrlKey || event.metaKey) {
+        if (event.key.toLowerCase() === 'z') {
+          this.canvasManager.undo();
+          event.preventDefault();
+        }
+        if (event.key.toLowerCase() === 'y') {
+          this.canvasManager.redo();
+          event.preventDefault();
+        }
+      }
+    });
+  }
+
+  populateGallery() {
+    this.galleryEl.innerHTML = '';
+    galleryImages.forEach((item) => {
+      const card = document.createElement('button');
+      card.className = 'gallery-item';
+      card.dataset.id = item.id;
+      card.dataset.src = item.src;
+      card.innerHTML = `<img src="${item.src}" alt="${item.title}" loading="lazy" /><span>${item.title}</span>`;
+      this.galleryEl.appendChild(card);
+    });
+  }
+
+  handleColorChange(color) {
+    this.canvasManager.setColor(color);
+  }
+
+  setStatus(message) {
+    this.statusEl.textContent = message;
+  }
+
+  persistSession(showToast = false) {
+    const snapshot = this.canvasManager.getSnapshot();
+    if (!snapshot) return;
+    const payload = {
+      width: this.canvasEl.width,
+      height: this.canvasEl.height,
+      data: Array.from(snapshot.data)
+    };
+    const success = saveSession(payload);
+    if (success && showToast) {
+      this.setStatus('Đã lưu tạm vào thiết bị.');
+    }
+  }
+
+  restoreSession() {
+    const session = loadSession();
+    if (!session) {
+      this.loadDefaultImage();
+      return;
+    }
+    const imageData = new ImageData(new Uint8ClampedArray(session.data), session.width, session.height);
+    this.canvasEl.width = session.width;
+    this.canvasEl.height = session.height;
+    this.canvasManager.ctx.putImageData(imageData, 0, 0);
+    this.canvasManager.pushHistory();
+    this.setStatus('Đã khôi phục bản vẽ trước đó.');
+  }
+
+  loadDefaultImage() {
+    const image = new Image();
+    image.onload = () => this.canvasManager.loadImage(image);
+    image.src = galleryImages[0].src;
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => new App());

--- a/src/js/canvas.js
+++ b/src/js/canvas.js
@@ -1,0 +1,244 @@
+import { clamp, getPointerPosition, hexToRgba } from './utils.js';
+import { floodFill } from './floodfill.js';
+
+const TOOL = {
+  BRUSH: 'brush',
+  ERASER: 'eraser',
+  BUCKET: 'bucket',
+  EYEDROPPER: 'eyedropper',
+  PAN: 'pan'
+};
+
+export class CanvasManager {
+  constructor(canvas, historyManager, statusCallback) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d', { willReadFrequently: true });
+    this.history = historyManager;
+    this.onStatus = statusCallback;
+    this.onColorPicked = null;
+    this.brushSize = 10;
+    this.fillTolerance = 32;
+    this.currentTool = TOOL.BRUSH;
+    this.currentColor = '#f87171';
+    this.isDrawing = false;
+    this.zoom = 1;
+    this.pan = { x: 0, y: 0 };
+    this.lastPointer = null;
+    this.activeImage = null;
+    this.gradientEnabled = false;
+    this.previousTool = TOOL.BRUSH;
+
+    this.setupEvents();
+    this.pushHistory();
+    this.updateTransform();
+  }
+
+  setupEvents() {
+    const pointerDown = (event) => {
+      if (event.button === 1) {
+        this.previousTool = this.currentTool;
+        this.currentTool = TOOL.PAN;
+      }
+      this.canvas.setPointerCapture(event.pointerId);
+      this.isDrawing = true;
+      this.lastPointer = getPointerPosition(event, this.canvas);
+      switch (this.currentTool) {
+        case TOOL.BRUSH:
+        case TOOL.ERASER:
+          this.drawPoint(this.lastPointer);
+          break;
+        case TOOL.BUCKET:
+          this.bucketFill(this.lastPointer);
+          break;
+        case TOOL.EYEDROPPER:
+          const color = this.pickColor(this.lastPointer);
+          this.onColorPicked?.(color);
+          break;
+        default:
+          break;
+      }
+    };
+
+    const pointerMove = (event) => {
+      if (!this.isDrawing) return;
+      const pointer = getPointerPosition(event, this.canvas);
+      switch (this.currentTool) {
+        case TOOL.BRUSH:
+          this.drawStroke(pointer);
+          break;
+        case TOOL.ERASER:
+          this.drawStroke(pointer, true);
+          break;
+        case TOOL.PAN:
+          this.panCanvas(event.movementX, event.movementY);
+          break;
+        default:
+          break;
+      }
+      this.lastPointer = pointer;
+    };
+
+    const pointerUp = (event) => {
+      this.canvas.releasePointerCapture(event.pointerId);
+      if (this.isDrawing && [TOOL.BRUSH, TOOL.ERASER, TOOL.BUCKET].includes(this.currentTool)) {
+        this.pushHistory();
+      }
+      if (event.button === 1) {
+        this.currentTool = this.previousTool ?? TOOL.BRUSH;
+      }
+      this.isDrawing = false;
+      this.lastPointer = null;
+    };
+
+    this.canvas.addEventListener('pointerdown', pointerDown);
+    this.canvas.addEventListener('pointermove', pointerMove);
+    window.addEventListener('pointerup', pointerUp);
+  }
+
+  loadImage(image) {
+    this.activeImage = image;
+    const { width, height } = image;
+    this.canvas.width = width;
+    this.canvas.height = height;
+    this.ctx.clearRect(0, 0, width, height);
+    this.ctx.drawImage(image, 0, 0, width, height);
+    this.pushHistory();
+    this.onStatus?.('Đã tải tranh.');
+  }
+
+  setBrushSize(size) {
+    this.brushSize = clamp(size, 1, 50);
+  }
+
+  setFillTolerance(value) {
+    this.fillTolerance = clamp(value, 0, 128);
+  }
+
+  setGradient(enabled) {
+    this.gradientEnabled = enabled;
+  }
+
+  setZoom(percentage) {
+    this.zoom = clamp(percentage / 100, 0.25, 4);
+    this.updateTransform();
+  }
+
+  panCanvas(dx, dy) {
+    this.pan.x += dx / this.zoom;
+    this.pan.y += dy / this.zoom;
+    this.updateTransform();
+  }
+
+  setTool(tool) {
+    this.currentTool = tool;
+  }
+
+  setColor(color) {
+    this.currentColor = color;
+  }
+
+  setColorPickedCallback(callback) {
+    this.onColorPicked = callback;
+  }
+
+  drawPoint({ x, y }) {
+    this.ctx.save();
+    this.ctx.lineCap = 'round';
+    this.ctx.lineJoin = 'round';
+    this.ctx.strokeStyle = this.currentTool === TOOL.ERASER ? '#ffffff' : this.currentColor;
+    this.ctx.fillStyle = this.ctx.strokeStyle;
+    this.ctx.lineWidth = this.brushSize;
+    this.ctx.beginPath();
+    this.ctx.arc(x, y, this.brushSize / 2, 0, Math.PI * 2);
+    this.ctx.fill();
+    this.ctx.restore();
+  }
+
+  drawStroke(pointer, erase = false) {
+    if (!this.lastPointer) return;
+    this.ctx.save();
+    this.ctx.lineCap = 'round';
+    this.ctx.lineJoin = 'round';
+    this.ctx.strokeStyle = erase ? '#ffffff' : this.currentColor;
+    this.ctx.lineWidth = this.brushSize;
+    this.ctx.beginPath();
+    this.ctx.moveTo(this.lastPointer.x, this.lastPointer.y);
+    this.ctx.lineTo(pointer.x, pointer.y);
+    this.ctx.stroke();
+    this.ctx.restore();
+  }
+
+  bucketFill(pointer) {
+    const rgba = hexToRgba(this.currentColor);
+    const gradient = this.gradientEnabled
+      ? (t) => {
+          const start = hexToRgba(this.currentColor);
+          const end = [start[0] * 0.7, start[1] * 0.7, start[2] * 0.7, 255];
+          return [
+            Math.round(start[0] + (end[0] - start[0]) * t),
+            Math.round(start[1] + (end[1] - start[1]) * t),
+            Math.round(start[2] + (end[2] - start[2]) * t),
+            255
+          ];
+        }
+      : null;
+
+    floodFill(this.ctx, pointer.x, pointer.y, rgba, this.fillTolerance, gradient);
+  }
+
+  pickColor(pointer) {
+    const pixel = this.ctx.getImageData(Math.floor(pointer.x), Math.floor(pointer.y), 1, 1).data;
+    const hex = `#${[pixel[0], pixel[1], pixel[2]]
+      .map((value) => value.toString(16).padStart(2, '0'))
+      .join('')}`;
+    this.onStatus?.(`Đã chọn màu ${hex}`);
+    this.currentColor = hex;
+    return hex;
+  }
+
+  pushHistory() {
+    const snapshot = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
+    this.history.push(snapshot);
+  }
+
+  undo() {
+    const snapshot = this.history.undo();
+    if (snapshot) {
+      this.ctx.putImageData(snapshot, 0, 0);
+      this.onStatus?.('Đã hoàn tác.');
+    }
+  }
+
+  redo() {
+    const snapshot = this.history.redo();
+    if (snapshot) {
+      this.ctx.putImageData(snapshot, 0, 0);
+      this.onStatus?.('Đã làm lại.');
+    }
+  }
+
+  clear(confirmClear = true) {
+    if (!confirmClear || window.confirm('Bạn có chắc muốn xóa hết nội dung?')) {
+      this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+      if (this.activeImage) {
+        this.ctx.drawImage(this.activeImage, 0, 0);
+      }
+      this.pushHistory();
+      this.onStatus?.('Đã xóa canvas.');
+    }
+  }
+
+  exportImage(type = 'image/png') {
+    return this.canvas.toDataURL(type, 0.92);
+  }
+
+  getSnapshot() {
+    return this.history.peek();
+  }
+
+  updateTransform() {
+    this.canvas.style.transform = `translate(${this.pan.x}px, ${this.pan.y}px) scale(${this.zoom})`;
+  }
+}
+
+export { TOOL };

--- a/src/js/colorpicker.js
+++ b/src/js/colorpicker.js
@@ -1,0 +1,107 @@
+import { loadFavorites, saveFavorites } from './storage.js';
+
+const BASE_COLORS = [
+  '#000000',
+  '#ffffff',
+  '#f87171',
+  '#ef4444',
+  '#f97316',
+  '#fbbf24',
+  '#34d399',
+  '#10b981',
+  '#60a5fa',
+  '#3b82f6',
+  '#8b5cf6',
+  '#a855f7',
+  '#ec4899',
+  '#f472b6',
+  '#9ca3af',
+  '#6b7280',
+  '#facc15',
+  '#fb923c',
+  '#f59e0b',
+  '#a3e635',
+  '#22d3ee',
+  '#2dd4bf',
+  '#38bdf8',
+  '#14b8a6'
+];
+
+export class ColorPicker {
+  constructor({ basePaletteEl, favoritePaletteEl, activeColorEl, colorInput, addFavoriteBtn, onColorChange }) {
+    this.basePaletteEl = basePaletteEl;
+    this.favoritePaletteEl = favoritePaletteEl;
+    this.activeColorEl = activeColorEl;
+    this.colorInput = colorInput;
+    this.addFavoriteBtn = addFavoriteBtn;
+    this.onColorChange = onColorChange;
+    this.favoriteColors = loadFavorites();
+    this.activeColor = BASE_COLORS[2];
+  }
+
+  init() {
+    this.renderPalette(BASE_COLORS, this.basePaletteEl, false);
+    this.renderPalette(this.favoriteColors, this.favoritePaletteEl, true);
+    this.setActiveColor(this.activeColor);
+
+    this.basePaletteEl.addEventListener('click', (event) => {
+      const swatch = event.target.closest('.color-swatch');
+      if (swatch) {
+        this.setActiveColor(swatch.dataset.color);
+      }
+    });
+
+    this.favoritePaletteEl.addEventListener('click', (event) => {
+      const swatch = event.target.closest('.color-swatch');
+      if (swatch) {
+        this.setActiveColor(swatch.dataset.color);
+      }
+    });
+
+    this.colorInput.addEventListener('input', (event) => {
+      this.setActiveColor(event.target.value);
+    });
+
+    this.addFavoriteBtn.addEventListener('click', () => {
+      if (!this.favoriteColors.includes(this.activeColor) && this.favoriteColors.length < 12) {
+        this.favoriteColors.push(this.activeColor);
+        saveFavorites(this.favoriteColors);
+        this.renderPalette(this.favoriteColors, this.favoritePaletteEl, true);
+      }
+    });
+  }
+
+  renderPalette(colors, container, removable) {
+    container.innerHTML = '';
+    colors.forEach((color, index) => {
+      const swatch = document.createElement('button');
+      swatch.className = 'color-swatch';
+      swatch.style.background = color;
+      swatch.type = 'button';
+      swatch.setAttribute('aria-label', `Chọn màu ${color}`);
+      swatch.dataset.color = color;
+
+      if (removable) {
+        swatch.addEventListener('contextmenu', (event) => {
+          event.preventDefault();
+          this.favoriteColors.splice(index, 1);
+          saveFavorites(this.favoriteColors);
+          this.renderPalette(this.favoriteColors, this.favoritePaletteEl, true);
+        });
+      }
+
+      container.appendChild(swatch);
+    });
+  }
+
+  setActiveColor(color) {
+    this.activeColor = color;
+    this.activeColorEl.style.background = color;
+    this.colorInput.value = color;
+    this.onColorChange?.(color);
+  }
+
+  getColor() {
+    return this.activeColor;
+  }
+}

--- a/src/js/floodfill.js
+++ b/src/js/floodfill.js
@@ -1,0 +1,75 @@
+import { rgbaEquals } from './utils.js';
+
+export function floodFill(context, x, y, fillColor, tolerance = 0, gradient = null) {
+  const { width, height } = context.canvas;
+  const imageData = context.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  const index = (Math.floor(y) * width + Math.floor(x)) * 4;
+  const targetColor = [data[index], data[index + 1], data[index + 2], data[index + 3]];
+
+  if (rgbaEquals(targetColor, fillColor, tolerance) || rgbaEquals(targetColor, fillColor, 0)) {
+    return;
+  }
+
+  const stack = [[Math.floor(x), Math.floor(y)]];
+  const visited = new Uint8Array(width * height);
+
+  while (stack.length) {
+    let [currentX, currentY] = stack.pop();
+    let currentIndex = (currentY * width + currentX) * 4;
+
+    while (currentX >= 0 && rgbaEquals(targetColor, data.slice(currentIndex, currentIndex + 4), tolerance)) {
+      currentX -= 1;
+      currentIndex -= 4;
+    }
+
+    currentX += 1;
+    currentIndex += 4;
+
+    let spanAbove = false;
+    let spanBelow = false;
+
+    while (currentX < width && rgbaEquals(targetColor, data.slice(currentIndex, currentIndex + 4), tolerance)) {
+      const offset = currentY * width + currentX;
+      if (!visited[offset]) {
+        let color = fillColor;
+        if (gradient) {
+          const t = currentY / height;
+          color = gradient(t);
+        }
+        data[currentIndex] = color[0];
+        data[currentIndex + 1] = color[1];
+        data[currentIndex + 2] = color[2];
+        data[currentIndex + 3] = color[3];
+        visited[offset] = 1;
+      }
+
+      if (currentY > 0) {
+        const aboveOffset = (currentY - 1) * width + currentX;
+        const aboveIndex = aboveOffset * 4;
+        if (!spanAbove && rgbaEquals(targetColor, data.slice(aboveIndex, aboveIndex + 4), tolerance)) {
+          stack.push([currentX, currentY - 1]);
+          spanAbove = true;
+        } else if (spanAbove && !rgbaEquals(targetColor, data.slice(aboveIndex, aboveIndex + 4), tolerance)) {
+          spanAbove = false;
+        }
+      }
+
+      if (currentY < height - 1) {
+        const belowOffset = (currentY + 1) * width + currentX;
+        const belowIndex = belowOffset * 4;
+        if (!spanBelow && rgbaEquals(targetColor, data.slice(belowIndex, belowIndex + 4), tolerance)) {
+          stack.push([currentX, currentY + 1]);
+          spanBelow = true;
+        } else if (spanBelow && !rgbaEquals(targetColor, data.slice(belowIndex, belowIndex + 4), tolerance)) {
+          spanBelow = false;
+        }
+      }
+
+      currentX += 1;
+      currentIndex += 4;
+    }
+  }
+
+  context.putImageData(imageData, 0, 0);
+}

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -1,0 +1,47 @@
+export class HistoryManager {
+  constructor(limit = 50) {
+    this.limit = limit;
+    this.stack = [];
+    this.position = -1;
+  }
+
+  push(state) {
+    if (this.position < this.stack.length - 1) {
+      this.stack = this.stack.slice(0, this.position + 1);
+    }
+    this.stack.push(state);
+    if (this.stack.length > this.limit) {
+      this.stack.shift();
+    }
+    this.position = this.stack.length - 1;
+  }
+
+  canUndo() {
+    return this.position > 0;
+  }
+
+  canRedo() {
+    return this.position < this.stack.length - 1;
+  }
+
+  undo() {
+    if (!this.canUndo()) return null;
+    this.position -= 1;
+    return this.stack[this.position];
+  }
+
+  redo() {
+    if (!this.canRedo()) return null;
+    this.position += 1;
+    return this.stack[this.position];
+  }
+
+  peek() {
+    return this.stack[this.position] ?? null;
+  }
+
+  reset() {
+    this.stack = [];
+    this.position = -1;
+  }
+}

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1,0 +1,32 @@
+const STORAGE_KEY = 'tomautranh-session-v1';
+const FAVORITES_KEY = 'tomautranh-favorites-v1';
+
+export function saveSession(session) {
+  try {
+    const serialized = JSON.stringify(session);
+    localStorage.setItem(STORAGE_KEY, serialized);
+    return true;
+  } catch (error) {
+    console.error('Lưu session thất bại', error);
+    return false;
+  }
+}
+
+export function loadSession() {
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    return data ? JSON.parse(data) : null;
+  } catch (error) {
+    console.error('Không thể tải session', error);
+    return null;
+  }
+}
+
+export function saveFavorites(colors) {
+  localStorage.setItem(FAVORITES_KEY, JSON.stringify(colors));
+}
+
+export function loadFavorites() {
+  const data = localStorage.getItem(FAVORITES_KEY);
+  return data ? JSON.parse(data) : [];
+}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,47 @@
+export function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function hexToRgba(hex) {
+  const normalized = hex.replace('#', '');
+  const bigint = parseInt(normalized, 16);
+  const length = normalized.length;
+  if (length === 3) {
+    const r = (bigint >> 8) & 0xf;
+    const g = (bigint >> 4) & 0xf;
+    const b = bigint & 0xf;
+    return [r * 17, g * 17, b * 17, 255];
+  }
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return [r, g, b, 255];
+}
+
+export function rgbaEquals(a, b, tolerance = 0) {
+  return (
+    Math.abs(a[0] - b[0]) <= tolerance &&
+    Math.abs(a[1] - b[1]) <= tolerance &&
+    Math.abs(a[2] - b[2]) <= tolerance &&
+    Math.abs(a[3] - b[3]) <= tolerance
+  );
+}
+
+export function getPointerPosition(event, canvas) {
+  const rect = canvas.getBoundingClientRect();
+  const x = ((event.clientX ?? event.touches?.[0]?.clientX) - rect.left) * (canvas.width / rect.width);
+  const y = ((event.clientY ?? event.touches?.[0]?.clientY) - rect.top) * (canvas.height / rect.height);
+  return { x, y };
+}
+
+export function debounce(fn, delay = 200) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}
+
+export function formatPercentage(value) {
+  return `${Math.round(value)}%`;
+}


### PR DESCRIPTION
## Summary
- create a responsive HTML layout, styles, and sample SVG gallery assets for the coloring experience
- implement canvas tools including brush, eraser, flood fill, eyedropper, zoom/pan, undo/redo, and export in vanilla JavaScript
- add palette management with favorites, auto-save, and localStorage session restores

## Testing
- no automated tests were run (manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68d5844a8ec8832ea631332490a029c7